### PR TITLE
Add configurable args.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,22 @@ selecting `Python Refactor: Reorder Imports` from the command palette.
 
 ![Example usage from context menu](res/context-menu-example.gif)
 
+## Settings
+
+Below is an example of a [settings.json](https://code.visualstudio.com/Docs/customization/userandworkspace) file with settings relevant to
+vscode-reorder-python-imports.
+
+```json
+{
+    "reorder-python-imports.args": [
+        "--application-directories=.:src",
+        "--add-import 'from __future__ import absolute_import'",
+        "--add-import 'from __future__ import division'",
+        "--add-import 'from __future__ import print_function'"
+  ]
+}
+```
+
 ### Reordering on Save
 
 Reordering imports on save is also supported, but requires you to set the following in

--- a/package.json
+++ b/package.json
@@ -42,6 +42,17 @@
                     "when": "editorLangId == python"
                 }
             ]
+        },
+        "configuration": {
+            "title": "reorder-python-imports",
+            "properties": {
+                "reorder-python-imports.args": {
+                    "type": "array",
+                    "default": [],
+                    "scope": "resource",
+                    "description": "Command-line arguments passed to reorder-python-imports."
+                }
+            }
         }
     },
     "scripts": {

--- a/src/reorderImportsProvider.ts
+++ b/src/reorderImportsProvider.ts
@@ -71,8 +71,21 @@ export class ReorderImportsProvider implements CodeActionProvider {
             path.dirname(pythonPath),
             'reorder-python-imports'
         );
-        console.log('Reorder Path:', reorderPath);
 
+        const extSpecifiedArgs = ["--exit-zero-even-if-changed"];
+        const userSpecifiedArgs = workspace.getConfiguration("reorder-python-imports").get<string[]>("args");
+
+        let reorderArgs = userSpecifiedArgs || [];
+        
+        // Don't add arg if user has already specified it in conf
+        extSpecifiedArgs.map((arg) => {
+            if (!reorderArgs.includes(arg)) {
+                reorderArgs.push(arg);
+            }
+        });
+
+        console.log('Reorder Path:', reorderPath);
+        
         const input = doc.getText();
 
         const lastLine = doc.lineCount - 1;
@@ -84,7 +97,7 @@ export class ReorderImportsProvider implements CodeActionProvider {
             const [stdout, stderr] = await new Promise<[string, string]>(
                 (resolve, reject) => {
                     const reorderProcess: ChildProcess = exec(
-                        `${reorderPath} --exit-zero-even-if-changed -`,
+                        `${reorderPath} ${reorderArgs.join(" ")} -`,
                         { cwd: wksp.uri.fsPath },
                         (error, stdout, stderr) => {
                             if (error) {


### PR DESCRIPTION
Adds a settings entry for user defined arguments to be passed to `reorder-python-imports as requested in #4.

![image](https://user-images.githubusercontent.com/14882117/121342283-c61fab00-c921-11eb-876f-fbac216c9a6c.png)
