### PR TITLE
Enable config of reorder-python-imports path

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ your settings to prevent Microsoft's python extension from running `isort`:
 
 ## Requirements
 
-`reorder-python-imports` must be installed in the venv used by visual studio.
+`reorder-python-imports` must be installed in the venv used by visual studio, or user must
+config the path for `reorder-python-imports` in settings.
 
 ## Known Issues
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,8 @@
                 "vsce": "^2.15.0"
             },
             "engines": {
-                "node": "16",
-                "vscode": "^1.63.0"
+                "node": "18.0.0",
+                "vscode": "^1.77.0"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "reorder-python-imports",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "reorder-python-imports",
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "deep-equal": "^2.0.5"

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
         "Other"
     ],
     "engines": {
-        "vscode": "^1.63.0",
-        "node": "16"
+        "vscode": "^1.77.0",
+        "node": "18.0.0"
     },
     "activationEvents": [
         "onLanguage:python",
@@ -52,6 +52,11 @@
                     "default": [],
                     "scope": "resource",
                     "description": "Command-line arguments passed to reorder-python-imports."
+                },
+                "reorderPythonImports.path": {
+                    "type": "string",
+                    "default": "",
+                    "description": "Path to the reorder-python-imports executable"
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "reorder-python-imports",
     "displayName": "reorder-python-imports",
     "description": "Provides support for the reorder-python-imports tool for python",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "publisher": "thebutlah",
     "author": {
         "name": "Ryan Butler",

--- a/src/reorderImportsProvider.ts
+++ b/src/reorderImportsProvider.ts
@@ -1,5 +1,6 @@
 import { ChildProcess, exec } from 'child_process';
 import deepEqual from 'deep-equal';
+import * as os from 'os';
 import * as path from 'path';
 import {
     CancellationToken,
@@ -70,13 +71,25 @@ export class ReorderImportsProvider implements CodeActionProvider {
         let doc = editor.document;
         console.log('Reordering ' + doc.uri);
 
-        const pythonPath = getPythonPath();
+        let reorderPath: string | null = null;
 
-        let reorderPath = path.join(
-            path.dirname(pythonPath),
-            'reorder-python-imports'
-        );
+        const config = workspace.getConfiguration('reorderPythonImports');
+        let configPath = config.get<string>('path');
 
+        if (configPath) {
+            if (configPath.startsWith('~')) {
+                configPath = path.join(os.homedir(), configPath.slice(1));
+            }
+            configPath = path.resolve(configPath);
+            reorderPath = configPath;
+        } else {
+            const pythonPath = getPythonPath();
+
+            reorderPath = path.join(
+                path.dirname(pythonPath),
+                'reorder-python-imports'
+            );
+        }
         console.debug('Reorder Path:', reorderPath);
 
         const extSpecifiedArgs = ['--exit-zero-even-if-changed'];


### PR DESCRIPTION
Enable manually input path for reorder-python-imports like `~/.local/bin/reorder-python-imports.

Remove the limitation that `reorder-python-imports` must be installed in current virtual env, it can be installed globally.

User might install `reorder-python-imports` globally as it doesn't dependent on current python project

Tools
- `uv` can use  `uv tool install reorder-python-imports`
- `pipx` can use `pipx install reorder-python-imports`

will install `reorder-python-imports` at `~/.local/bin/reorder-python-imports`